### PR TITLE
:memo: fix links to images in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,22 @@ This theme was created to be optimized for front end web development - HTML, CSS
 Most of the dark themes I tried using were distracting and overly colorful and contrast heavy, especially with PHP embedded into HTML. The New Moon theme strives to remedy that, with a theme that is pleasant to view in any language.
 
 ## HTML
-![HTML Screenshot](https://github.com/taniarascia/new-moon-atom-syntax/blob/master/images/html.png)
+![HTML Screenshot](https://raw.githubusercontent.com/taniarascia/new-moon-atom-syntax/master/images/html.png)
 
 ## PHP
-![PHP Screenshot](https://github.com/taniarascia/new-moon-atom-syntax/blob/master/images/php.png)
+![PHP Screenshot](https://raw.githubusercontent.com/taniarascia/new-moon-atom-syntax/master/images/php.png)
 
 ## PHP/HTML
-![PHP Screenshot](https://github.com/taniarascia/new-moon-atom-syntax/blob/master/images/phphtml.png)
+![PHP Screenshot](https://raw.githubusercontent.com/taniarascia/new-moon-atom-syntax/master/images/phphtml.png)
 
 ## CSS
-![CSS Screenshot](https://github.com/taniarascia/new-moon-atom-syntax/blob/master/images/css.png)
+![CSS Screenshot](https://raw.githubusercontent.com/taniarascia/new-moon-atom-syntax/master/images/css.png)
 
 ## Sass
-![CSS Screenshot](https://github.com/taniarascia/new-moon-atom-syntax/blob/master/images/sass.png)
+![CSS Screenshot](https://raw.githubusercontent.com/taniarascia/new-moon-atom-syntax/master/images/sass.png)
 
 ## LESS
-![CSS Screenshot](https://github.com/taniarascia/new-moon-atom-syntax/blob/master/images/less.png)
+![CSS Screenshot](https://raw.githubusercontent.com/taniarascia/new-moon-atom-syntax/master/images/less.png)
 
 ## JavaScript
-![JS Screenshot](https://github.com/taniarascia/new-moon-atom-syntax/blob/master/images/js.png)
+![JS Screenshot](https://raw.githubusercontent.com/taniarascia/new-moon-atom-syntax/master/images/js.png)


### PR DESCRIPTION
### Scope
- fix links to screenshots in the README (as they are broken on the [atom page](https://atom.io/themes/new-moon-atom-syntax))

_Note:_ link to raw content can be done by clicking on the button "raw" from the old links, which redirects to the right page. 
