### PR TITLE
Bracket Matcher/Whitespace Fixes

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -354,11 +354,11 @@ atom-text-editor[mini] .scroll-view,
     background: @activeline-background;
   }
 }
-.bracket-matcher {
-    border-bottom: 1px solid lime;
+.bracket-matcher .region {
     position: absolute;
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    background-color: @matchingtag-background;
+    background: rgba(0, 0, 0, 0.4);
+    border: 1px solid rgba(162, 158, 158, 0.4);
+    border-bottom: 1px solid lime;
 }
 .leading-whitespace {
     color: rgba(0,0,0,0);

--- a/styles/base.less
+++ b/styles/base.less
@@ -355,13 +355,14 @@ atom-text-editor[mini] .scroll-view,
   }
 }
 .bracket-matcher .region {
-    position: absolute;
-    background: rgba(0, 0, 0, 0.4);
-    border: 1px solid rgba(162, 158, 158, 0.4);
-    border-bottom: 1px solid lime;
+  position: absolute;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(162, 158, 158, 0);
+  border-bottom: 1px solid lime;
+  transform: scale(1.15);
 }
 .leading-whitespace {
-    color: rgba(0,0,0,0);
-    position: relative;
-    box-shadow: inset 1px 0 0 rgba(255,255,255,0.1); // It force the shadow to have a different color than the text.
-  }
+  color: rgba(0,0,0,0);
+  position: relative;
+  box-shadow: inset 1px 0 0 rgba(255,255,255,0.1); // It force the shadow to have a different color than the text.
+}

--- a/styles/base.less
+++ b/styles/base.less
@@ -357,7 +357,6 @@ atom-text-editor[mini] .scroll-view,
 .bracket-matcher .region {
   position: absolute;
   background: rgba(0, 0, 0, 0.5);
-  border: 1px solid rgba(162, 158, 158, 0);
   border-bottom: 1px solid lime;
   transform: scale(1.15);
 }

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -11,7 +11,7 @@
 
 // Guide colors
 @syntax-wrap-guide-color: @selected-background;
-@syntax-indent-guide-color: white;
+@syntax-indent-guide-color: #4A4B4B;
 @syntax-invisible-character-color: @foreground;
 
 // For find and replace markers


### PR DESCRIPTION
These are some quick fixes for three issues:

-The color of the indent guide for a blank line was white, this was changed to be the same as the "normal" indent guide color, as in Brackets. (I feel like this is the most important change of the three.)

-The .bracket-matcher properties were applying to a span in Atom's gutter, causing a strange visual glitch where small pixels could be seen jumping around when the cursor was moved. I just made the selector more specific so it only applies to the tag.

-The .bracket-matcher properties were tweaked to more closely match the original Brackets version, while keeping the default green underline behavior of the Atom matcher.

I'll probably have a few more tweaks to get the Atom version closer to the original Brackets version, as I'm finding myself loading Atom a lot more than Brackets lately - and I want to keep using my favorite theme, of course!
