### PR TITLE
SCSS Atom/Brackets parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 New Moon Color Scheme for Atom
 ===========================
-###[Beautiful Syntax Highlighting](http://taniarascia.github.io/new-moon-atom-syntax/)
+###[Beautiful Syntax Highlighting](http://taniarascia.github.io/new-moon/)
 
 ![New Moon Icon](https://raw.githubusercontent.com/taniarascia/new-moon/master/images/newmoon.png)
 
@@ -11,8 +11,6 @@ New Moon Color Scheme for Atom
 This theme was created to be optimized for front end web development - HTML, CSS, JavaScript and PHP/Wordpress. It's a middle-contrast dark theme using color inspiration from Tomorrow Night Eighties, and style inspiration from Twilight.
 
 Most of the dark themes I tried using were distracting and overly colorful and contrast heavy, especially with PHP embedded into HTML. The New Moon theme strives to remedy that, with a theme that is pleasant to view in any language.
-
-**[Official Brackets Registry](http://brackets.dnbard.com/extension/new-moon)**
 
 **Installation**
 

--- a/README.md
+++ b/README.md
@@ -19,28 +19,25 @@ Most of the dark themes I tried using were distracting and overly colorful and c
 * Click `Install`
 
 ## HTML
-![HTML Screenshot](https://github.com/taniarascia/new-moon/blob/master/images/html.png)
+![HTML Screenshot](https://raw.githubusercontent.com/taniarascia/new-moon-atom-syntax/master/images/html.png)
 
 ## PHP
-![PHP Screenshot](https://github.com/taniarascia/new-moon/blob/master/images/php.png)
+![PHP Screenshot](https://raw.githubusercontent.com/taniarascia/new-moon-atom-syntax/master/images/php.png)
 
 ## PHP/HTML
-![PHP Screenshot](https://github.com/taniarascia/new-moon/blob/master/images/htmlphp.png)
+![PHP HTML Screenshot](https://raw.githubusercontent.com/taniarascia/new-moon-atom-syntax/master/images/htmlphp.png)
 
 ## CSS
-![CSS Screenshot](https://github.com/taniarascia/new-moon/blob/master/images/css.png)
+![CSS Screenshot](https://raw.githubusercontent.com/taniarascia/new-moon-atom-syntax/master/images/css.png)
 
 ## Sass/SCSS
-![SCSS Screenshot](https://github.com/taniarascia/new-moon/blob/master/images/scss.png)
+![CSS Screenshot](https://raw.githubusercontent.com/taniarascia/new-moon-atom-syntax/master/images/scss.png)
 
 ## LESS
-![LESS Screenshot](https://github.com/taniarascia/new-moon/blob/master/images/less.png)
+![CSS Screenshot](https://raw.githubusercontent.com/taniarascia/new-moon-atom-syntax/master/images/less.png)
 
 ## JavaScript
-![JS Screenshot](https://github.com/taniarascia/new-moon/blob/master/images/js.png)
+![JS Screenshot](https://raw.githubusercontent.com/taniarascia/new-moon-atom-syntax/master/images/js.png)
 
 ## jQuery
-![jQuery Screenshot](https://github.com/taniarascia/new-moon/blob/master/images/jquery.png)
-
-## Markdown
-![MD Screenshot](https://github.com/taniarascia/new-moon/blob/master/images/md.png)
+![jQuery Screenshot](https://raw.githubusercontent.com/taniarascia/new-moon-atom-syntax/master/images/jquery.png) 

--- a/styles/base.less
+++ b/styles/base.less
@@ -10,6 +10,8 @@ atom-text-editor, :host {
 
   .indent-guide {
     color: @syntax-indent-guide-color;
+    position: relative;
+    box-shadow: inset 1px 0 0 rgba(255,255,255,0.1);
   }
 
   .invisible-character {
@@ -82,7 +84,7 @@ atom-text-editor .search-results .marker.current-result .region,
   color: @keyword;
 
   &.control {
-    color: @tag;
+    color: @variable;
   }
 
   &.operator {
@@ -103,7 +105,7 @@ atom-text-editor .search-results .marker.current-result .region,
 }
 
 .constant {
-  color: @orange;
+  color: @id;
 
   &.character.escape {
     color: @cyan;
@@ -114,7 +116,7 @@ atom-text-editor .search-results .marker.current-result .region,
   }
 
   &.other.color {
-    color: @cyan;
+    color: @id;
   }
 
   &.other.symbol {
@@ -133,6 +135,7 @@ atom-text-editor .search-results .marker.current-result .region,
     color: @syntax-text-color;
   }
 }
+
 
 .invalid.illegal {
 //  background-color: @red;
@@ -202,7 +205,12 @@ atom-text-editor .search-results .marker.current-result .region,
     &.any-method {
       color: @blue;
     }
+
+    &.misc.scss {
+      color: @tag;
+    }
   }
+
 }
 
 .entity {
@@ -221,14 +229,19 @@ atom-text-editor .search-results .marker.current-result .region,
   &.name.tag {
     color: @tag;
     //text-decoration: underline;
+    &.reference {
+      color: @very-light-gray;
+    }
   }
 
   &.other.attribute-name {
-    color: @orange;
+    color: @variable;
 
     &.id {
       color: @id;
     }
+
+
   }
 }
 
@@ -325,7 +338,7 @@ atom-text-editor[mini] .scroll-view,
   color: @variable;
 }
 .constant.other.color.rgb-value.scss {
-  color: @definition;
+  color: @id;
 }
 .keyword.other.unit {
   color: @number;

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -11,7 +11,7 @@
 
 // Guide colors
 @syntax-wrap-guide-color: @selected-background;
-@syntax-indent-guide-color: #4A4B4B;
+@syntax-indent-guide-color: black;
 @syntax-invisible-character-color: @foreground;
 
 // For find and replace markers


### PR DESCRIPTION
These are centered mostly on SCSS, as that's what we use at work. It's been incredibly slow today, so I've been more nitpicky with my port - at some point I'll try to go through the other languages and get them synced up as well, but that depends on my free time.. As an example, jQuery is quite a bit different than the Brackets version. Not _bad_, mind you. Just.. different.

Anyway, the only scss element not matched is one type of variable which Atom doesn't have a selector for. If the value of a variable is an integer or a hex value it will match, but not when the value is a string. For now I've left string values the same pink color as the hex value, rather than the white which Brackets uses -- and I doubt anyone would notice the difference unless they have them both open side by side like I'm doing.

Also:
-Fixed another super nitpicky issue with the indent guide / leading whitespace where selections would cause the indent guide to no longer match. I just copied the code you used for the whitespace selector and made the two identical.

-There was a broken link when I copied over the readme from the Brackets repo, because apparently I was on autopilot and added an 'atom-syntax' to the end of the link. (Sorry.)

Relatedly, I noticed the preview images are broken on the [Atom theme page.](https://atom.io/themes/new-moon-atom-syntax)  Which also must have been my doing. Everything was copied direct from the Brackets repo so that _(in theory)_ the newer image previews would show.. but I don't know what the hell I did, because it clearly didn't work, lol. So all the image URLs have been restored to how you had them on Nov 28th.

So that said, the next pull req proably won't be for a bit, and I'll try not to write half a novel for ten lines of minor code changes the next time I do one.
